### PR TITLE
Bob sends a public key, not an address

### DIFF
--- a/DIAGRAM.txt
+++ b/DIAGRAM.txt
@@ -6,7 +6,7 @@ Alice is a client who want to open a payment channel with Bob the merchant.
   [ Alice ]                             [ Bob ]
       |                                    |
       |--- Initiate PC ------------------->|
-      |<---------------- Return address ---|
+      |<---------------- Return pubkey ----|
       |                                    |
       |                                    |
 **Serialize                                |
@@ -28,3 +28,4 @@ Alice is a client who want to open a payment channel with Bob the merchant.
                 PC now closed
 
 PC: "Payment Channel"
+pubkey: "Public key"


### PR DESCRIPTION
Addresses cannot be reversed to public keys because they are RIPEMD160 hash digests of a public key, so the actual data needs to be a public key :-)